### PR TITLE
[APP-1252] Use relative date instead of fixed date

### DIFF
--- a/examples/smoke-test.mjs
+++ b/examples/smoke-test.mjs
@@ -86,6 +86,15 @@ const usage = await client.info.getUsage()
 console.log("Entity summary usage: ", usage.usage.entity)
 
 // History
-const history = await client.info.getHistory({size: 10000, from_: "2024-04-20", to: "2024-04-21"})
-console.log("Found", history.events.length, "events from 2024-04-20 to 2024-04-21")
+const now = new Date()
+const fromDate = new Date(now)
+fromDate.setDate(now.getDate() - 30)
+const endDate = new Date(now)
+endDate.setDate(now.getDate() - 29)
+
+const fromDateStr = fromDate.toISOString().split('T')[0]
+const endDateStr = endDate.toISOString().split('T')[0]
+
+const history = await client.info.getHistory({ size: 10000, from_: fromDateStr, to: endDateStr })
+console.log("Found", history.events.length, "events from", fromDateStr, "to", endDateStr)
 


### PR DESCRIPTION
- uses relative dates instead of fixed dates to avoid going over 1 year limit

Testing the date generation part in node cli:
```
node 
Welcome to Node.js v20.11.0.
Type ".help" for more information.
> const now = new Date()
undefined
> const fromDate = new Date(now)
undefined
> fromDate.setDate(now.getDate() - 30)
1743354597302
> const endDate = new Date(now)
undefined
> endDate.setDate(now.getDate() - 29)
1743440997302
> 
> const fromDateStr = fromDate.toISOString().split('T')[0]
undefined
> const endDateStr = endDate.toISOString().split('T')[0]
undefined
> console.log(fromDateStr, endDateStr)
2025-03-30 2025-03-31
undefined
> 
```

running smoke tests locally returns:
```
node examples/smoke-test.mjs
Found 250 sources
First source is: Acuris Risk Intelligence Adverse Media Data
Found 52 entity results for  victoria beckham limited
Has address: SAUNDERS BUILDING, 202 HAMMERSMITH ROAD, HAMMERSMITH, LONDON
Is referenced by 100 sources
Resolved to 1 entities
Found 100 records.
a7e5a83df5551eb557688c84451abd9d/0000950123-09-004358-index.htm/1680718045978
Found record: Company Record from USA SEC 10-K Database
Did traversal of entity mGq1lpuqKssNWTjIokuPeA Found 20 related things.
Found 17 beneficial owners
Found 12 downstream things owned by the first UBO of victoria beckham limited
Found 20 watchlist results for entity s2n28a_qvIeKxaLz4sf4Rw
Found path with 1 hops
Entity summary usage:  undefined
Found 0 events from 2025-03-30 to 2025-03-31
```