### PR TITLE
fix: correct npmMinimalAgeGate to yarn duration-string format

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,1 @@
-npmMinimalAgeGate: 10080
+npmMinimalAgeGate: "7d"


### PR DESCRIPTION
## Summary

Corrects the `npmMinimalAgeGate` value in `.yarnrc.yml` from an integer (`10080`) to the correct yarn duration-string format (`"7d"`).

## Problem

Yarn uses a **duration-string format** for `npmMinimalAgeGate` (e.g. `"7d"`, `"168h"`, `"10080m"`), not plain integer minutes like pnpm. The value `10080` is an unrecognised format — yarn cannot parse it and silently ignores the gate, meaning the 7-day cooldown protection was **not actually enforced**.

## Fix

```diff
- npmMinimalAgeGate: 10080
+ npmMinimalAgeGate: "7d"
```

Both express 7 days, but only `"7d"` is valid for yarn.

**Ref:** https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate

🤖 Generated with [Claude Code](https://claude.com/claude-code)